### PR TITLE
Extend number of string or num argument placeholders to be unlimited

### DIFF
--- a/as2f/src/main/kotlin/dev/vishna/as2f/AndroidStrings.kt
+++ b/as2f/src/main/kotlin/dev/vishna/as2f/AndroidStrings.kt
@@ -6,7 +6,6 @@ import org.w3c.dom.NodeList
 import java.io.File
 import java.io.InputStream
 import java.lang.IllegalArgumentException
-import java.util.*
 import javax.xml.parsers.DocumentBuilderFactory
 
 data class AndroidStrings(
@@ -129,9 +128,23 @@ fun Map<String, String>.asArbText() : String {
  * very unoptimized converter
  */
 private fun String.toArb() : String {
-    var input = this
+    var input: String = this
+    val regexArgs = Regex("%([1-9]+)s")
+    val regexNums = Regex("%([1-9]+)d")
     replacementMap.forEach { key, value ->
-        input = input.replace(key, value)
+        val findArgs: Boolean = !regexArgs.findAll(key).toList().isNullOrEmpty()
+        val findNums: Boolean  = !regexNums.findAll(key).toList().isNullOrEmpty()
+        when {
+            findArgs -> {
+                input = input.replace(regexArgs, value)
+            }
+            findNums -> {
+                input = input.replace(regexNums, value)
+            }
+            else -> {
+                input = input.replace(key, value)
+            }
+        }
     }
     return input
 }
@@ -139,10 +152,6 @@ private fun String.toArb() : String {
 private val replacementMap = mapOf(
         "%s" to "\${arg}",
         "%d" to "\${num}",
-        "%1\$s" to "\${arg1}",
-        "%2\$s" to "\${arg2}",
-        "%1\$d" to "\${num1}",
-        "%2\$d" to "\${num2}",
         "%%" to "%",
         "\n" to " ",
         "\\\'" to "'",

--- a/as2f/src/test/kotlin/dev/vishna/as2f/CoreTest.kt
+++ b/as2f/src/test/kotlin/dev/vishna/as2f/CoreTest.kt
@@ -49,9 +49,14 @@ class CoreTest {
     }
 
     @Test fun findArgs() {
-        val expressionWithSomeArgs = "沒有在\${arg1}的\"\${arg2}\"結果"
+        val expressionWithSomeArgs = "沒有在\${arg1}的\"\${arg2}\"結果是\${arg3}\"好的\${arg4}\"好的\${arg5}\"好的\${arg6}\"好的"
         val args = expressionWithSomeArgs.findArgs()
-        args `should contain all` listOf("arg1", "arg2")
+        args `should contain all` listOf("arg1", "arg2", "arg3", "arg4", "arg5", "arg6")
     }
 
+    @Test fun findNums() {
+        val expressionWithSomeArgs = "沒有在\${num1}的\"\${num2}\"結果是\${num3}\"好的\${num4}\"好的\${num5}\"好的\${num6}\"好的"
+        val args = expressionWithSomeArgs.findArgs()
+        args `should contain all` listOf("num1", "num2", "num3", "num4", "num5", "num6")
+    }
 }


### PR DESCRIPTION
I am not sure whether it was your intension to ignore more possible string-based arguments or number based ones. 
Maybe I am wrong. But in our project, we really need to have arguments more than two under the hood.
So I provide this PR, maybe you can extend the library sincerely 😉 

Thank you.